### PR TITLE
Configured to build for Win, Mac and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ cd <your-project-name> && npm install
 ```
 npm run start
 ```
+5. Edit package.json file with the appropriate details of your project.
+'''
 ## Deploy to Desktop
 1. Run the build process
 ```

--- a/package.json
+++ b/package.json
@@ -5,8 +5,26 @@
   "author": "willjw3",
   "build": {
     "appId": "react.electron",
+    "productName": "react-electron",
+    "mac":{
+      "icon": "build/logo512.png",
+      "target": "tar.gz"
+    },
+    "linux": {
+      "category": "Utils",
+      "icon": "build/icon.png",
+      "packageCategory": "utils",
+      "maintainer": "your name <your email>",
+      "asar": true,
+      "target": [
+        "deb",
+        "tar.xz"
+      ],
+      "synopsis": "Basically same as description but shorter"
+    },
     "win": {
-      "icon": "build/icon.png"
+      "icon": "build/icon.png",
+      "target": "nsis"
     }
   },
   "main": "public/electron.js",
@@ -26,7 +44,7 @@
     "test-react": "react-scripts test --env=jsdom",
     "eject-react": "react-scripts eject",
     "build-electron": "electron-builder",
-    "build": "yarn build-react && yarn build-electron",
+    "build": "yarn build-react && yarn build-electron -wml",
     "start": "concurrently \"cross-env BROWSER=none yarn start-react\" \"wait-on http://localhost:3000 && electron .\""
   },
   "eslintConfig": {


### PR DESCRIPTION
Edited package.json so that the build process will build for Windows, Mac and Linux at the same time.

David Isakson <david.isakson.ii@gmail.com>

Example: 
  "scripts": {
    "start-react": "react-scripts start",
    "build-react": "react-scripts build",
    "test-react": "react-scripts test --env=jsdom",
    "eject-react": "react-scripts eject",
    "build-electron": "electron-builder -wml", <--: w = Windows, m=Mac, l=Linux
    "build": "yarn build-react && yarn build-electron",
    "start": "concurrently \"cross-env BROWSER=none yarn start-react\" \"wait-on http://localhost:3000 && electron .\""
  },

Note about Mac build:

"mac":{
      "icon": "build/logo512.png", <--: icon size must be at least 512 x 512
      "target": "tar.gz" <--:Unless you are on a Mac you can not build with DMG, MAS or PKG as the target.
    },

Note about Windows build:
    Linux users who wish to make a Windows build must install Wine for the build to be successful.

Note about Linux build:
"linux": {
      "category": "Utils",<--:This is for the placement in the GUI menu
      "icon": "build/icon.png",<--:optional
      "packageCategory": "utils",
      "maintainer": "your name <your email>",<--:Will default to author
      "asar": true,
      "target": [
        "deb", <--:For Debian, Ubuntu and Ubuntu based Distributions 
        "tar.xz" <--:Completely optional but should work with most Linux Distributions
      ],
      "synopsis": "Basically same as description but shorter"
